### PR TITLE
handle *.mjs and *.cjs files identical to .js files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -138,7 +138,7 @@ const tsRules = {
     '@typescript-eslint/consistent-type-exports': 'error',
 };
 
-/** Separate config for .js files which is applied internally */
+/** Separate config for .js, *.cjs and *.mjs files which is applied internally */
 const plainJsConfig = {
     ...tseslint.configs.disableTypeChecked,
     rules: {
@@ -173,7 +173,7 @@ export default tseslint.config(
         rules: tsRules,
     },
     {
-        files: ['**/*.js'],
+        files: ['**/*.js', '**/*.cjs', '**/*.mjs' ],
         ...plainJsConfig,
     },
 );


### PR DESCRIPTION
js files could have the extension mjs or cjs to force commonJs or ESM mode. Those extensions are standardized. So could (and should) be handled by default eslint config like *.js files.