### PR TITLE
Disable jsdoc no types javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ It is suggested to create separate `eslint.config.mjs` files for backend and for
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+
+### **WORK IN PROGRESS**
+-   (@foxriver76) Disable `jsdoc/no-types` off for non-TypeScript files
+-   (@mcm1957) Apply JavaScript rules also to `.mjs` and `.cjs` files
+
 ### 1.0.0 (2024-11-17)
 
 -   (@GermanBluefox) Added `no-duplicate-imports` rule

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 /**
  * Rules for all JSDOC plugin usages
  */
-const jsdocRules = {
+const jsdocBaseRules = {
     'jsdoc/require-returns': 0,
     'jsdoc/tag-lines': ['error', 'never', { startLines: 1 }],
     'jsdoc/no-blank-blocks': ['error', { enableFixer: true }],
@@ -22,6 +22,11 @@ const jsdocRules = {
             contexts: ['TSInterfaceDeclaration', 'TSMethodSignature', 'TSPropertySignature'],
         },
     ],
+};
+
+const jsDocJsRules = {
+    ...jsdocBaseRules,
+    'jsdoc/no-types': 0,
 };
 
 /**
@@ -138,14 +143,14 @@ const tsRules = {
     '@typescript-eslint/consistent-type-exports': 'error',
 };
 
-/** Separate config for .js, *.cjs and *.mjs files which is applied internally */
+/** Separate config for .js, .cjs and .mjs files which is applied internally */
 const plainJsConfig = {
     ...tseslint.configs.disableTypeChecked,
     rules: {
         ...tseslint.configs.disableTypeChecked.rules,
         '@typescript-eslint/no-require-imports': 'off',
-    }
-}
+    },
+};
 
 /** @type {import("eslint").Linter.FlatConfig[]} */
 export default tseslint.config(
@@ -163,7 +168,13 @@ export default tseslint.config(
     },
     {
         plugins: { jsdoc },
-        rules: jsdocRules,
+        files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
+        rules: jsDocJsRules,
+    },
+    {
+        plugins: { jsdoc },
+        files: ['**/*.ts', '**/*.tsx'],
+        rules: jsdocBaseRules,
     },
     {
         rules: generalRules,
@@ -173,7 +184,7 @@ export default tseslint.config(
         rules: tsRules,
     },
     {
-        files: ['**/*.js', '**/*.cjs', '**/*.mjs' ],
+        files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
         ...plainJsConfig,
     },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,7 @@ const jsdocTsRules = {
 /**
  * Specific rules for jsdoc plugin onn plain JS files
  */
-const jsDocJsRules = {
+const jsdocJsRules = {
     ...jsdocTsRules,
     'jsdoc/no-types': 0,
 };
@@ -177,7 +177,7 @@ export default tseslint.config(
     {
         plugins: { jsdoc },
         files: JS_SELECTOR,
-        rules: jsDocJsRules,
+        rules: jsdocJsRules,
     },
     {
         plugins: { jsdoc },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,10 +7,15 @@ import globals from 'globals';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 
+/** Glob patterns for TypeScript rules */
+const TS_SELECTOR = ['**/*.ts', '**/*.tsx'];
+/** Glob patterns for JavaScript rules */
+const JS_SELECTOR = ['**/*.js', '**/*.cjs', '**/*.mjs'];
+
 /**
- * Rules for all JSDOC plugin usages
+ * Rules for JSDOC plugin usages on TypeScript files
  */
-const jsdocBaseRules = {
+const jsdocTsRules = {
     'jsdoc/require-returns': 0,
     'jsdoc/tag-lines': ['error', 'never', { startLines: 1 }],
     'jsdoc/no-blank-blocks': ['error', { enableFixer: true }],
@@ -24,8 +29,11 @@ const jsdocBaseRules = {
     ],
 };
 
+/**
+ * Specific rules for jsdoc plugin onn plain JS files
+ */
 const jsDocJsRules = {
-    ...jsdocBaseRules,
+    ...jsdocTsRules,
     'jsdoc/no-types': 0,
 };
 
@@ -168,23 +176,23 @@ export default tseslint.config(
     },
     {
         plugins: { jsdoc },
-        files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
+        files: JS_SELECTOR,
         rules: jsDocJsRules,
     },
     {
         plugins: { jsdoc },
-        files: ['**/*.ts', '**/*.tsx'],
-        rules: jsdocBaseRules,
+        files: TS_SELECTOR,
+        rules: jsdocTsRules,
     },
     {
         rules: generalRules,
     },
     {
-        files: ['**/*.ts', '**/*.tsx'],
+        files: TS_SELECTOR,
         rules: tsRules,
     },
     {
-        files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
+        files: JS_SELECTOR,
         ...plainJsConfig,
     },
 );


### PR DESCRIPTION
For plain js files it makes sense to hava jsdoc type params, we just wanted to avoid redundancy for TS files

closes #29 