### PR TITLE
[OFFICIAL RELEASE] 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ It is suggested to create separate `eslint.config.mjs` files for backend and for
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
-
-### **WORK IN PROGRESS**
+### 1.0.1 (2025-03-04)
 -   (@foxriver76) Disable `jsdoc/no-types` off for non-TypeScript files
 -   (@mcm1957) Apply JavaScript rules also to `.mjs` and `.cjs` files
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iobroker/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iobroker/eslint-config",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@alcalzone/release-script": "^3.8.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iobroker/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Eslint config of ioBroker",
   "homepage": "https://github.com/ioBroker/ioBroker.eslint-config",
   "main": "eslint.config.mjs",


### PR DESCRIPTION
-   (@foxriver76) Disable `jsdoc/no-types` off for non-TypeScript files
-   (@mcm1957) Apply JavaScript rules also to `.mjs` and `.cjs` files