### PR TITLE
remove typescript peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It is suggested to create separate `eslint.config.mjs` files for backend and for
 -->
 ### **WORK IN PROGRESS**
 
--   (mcm1957) remove typescript peerDependency
+-   (mcm1957) typescript peerDependency has been removed
   
 ### 2.0.0 (2025-03-04)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ It is suggested to create separate `eslint.config.mjs` files for backend and for
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+-   (mcm1957) remove typescript peerDependency
+  
 ### 2.0.0 (2025-03-04)
 
 -   (@GermanBluefox) Some eslint packages were updated with major version (TypeScript 5.8)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "eslint-plugin-unicorn": "^57.0.0",
     "globals": "^16.0.0",
     "prettier": "^3.5.3",
-    "typescript": "~5.8.2",
     "typescript-eslint": "^8.26.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR removes peerDependency for typescript

Requiring typescript to be  ~5.8.0 blocks installation of eslint-config@2.0.0 as log as an older typescript version is installed. Otherwise updating typescript to 5.8.x is not possible as long as eslint-confi@1.x.x is installed - at least not without ignoring errors.

Until 2.0.0 typescript was not listed as peerDependency. I do not see a reason to request / check this as eslint typeScript plugin(s) anyway check the supported typescript version. And eslint-config itself does not use tyoescript or an special feature of it.

So eslint-config should not require a specific typescript version to allow a smooth installtion.

